### PR TITLE
Removed outdated info regarding connection mode

### DIFF
--- a/jellyfin.subdomain.conf.sample
+++ b/jellyfin.subdomain.conf.sample
@@ -3,8 +3,7 @@
 # if jellyfin is running in bridge mode and the container is named "jellyfin", the below config should work as is
 # if not, replace the line "set $upstream_app jellyfin;" with "set $upstream_app <containername>;"
 # or "set $upstream_app <HOSTIP>;" for host mode, HOSTIP being the IP address of jellyfin
-# in jellyfin settings, under "Advanced/Networking" change the public https port to 443, leave the local ports as is,
-# and set the "Secure connection mode" to "Handled by reverse proxy"
+# in jellyfin settings, under "Advanced/Networking" change the public https port to 443, and leave the local ports as is
 
 server {
     listen 443 ssl;


### PR DESCRIPTION
"Secure connection mode" is not part of the settings page anymore, so it's confusing to have it in the instructions.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]